### PR TITLE
Watch task runs the build automatically

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,6 @@ end
 gem 'rails', '~> 5.0.1'
 # Use Puma as the app server
 gem 'puma', '~> 3.0'
-# Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 # Set the templating engine to haml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,6 @@ GEM
     concurrent-ruby (1.0.4)
     debug_inspector (0.0.2)
     erubis (2.7.0)
-    execjs (2.7.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     haml (4.0.7)
@@ -146,8 +145,6 @@ GEM
       thread_safe (~> 0.1)
     tzinfo-data (1.2016.10)
       tzinfo (>= 1.0.0)
-    uglifier (3.0.4)
-      execjs (>= 0.3.0, < 3)
     web-console (3.4.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -174,7 +171,6 @@ DEPENDENCIES
   sqlite3
   turbolinks (~> 5)
   tzinfo-data
-  uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
 
 BUNDLED WITH

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,5 +45,5 @@ gulp.task('watch:sass', () => {
   gulp.watch('app/gulp/css/**/*.css', ['build:css']);
 });
 
-gulp.task('watch', ['watch:js', 'watch:sass']);
 gulp.task('build', ['build:js', 'build:sass']);
+gulp.task('watch', ['build', 'watch:js', 'watch:sass']);


### PR DESCRIPTION
## Changes <!-- What does this pull request do/change? -->
Fix the issue that @rmkeezer encountered where it's possible to run the watch task without having built anything previously. The watch task now automatically runs the build as well.

## Context <!-- Is there some background that reviewers need? -->
See Slack.

## Testing <!-- What's the best way to try out the changes manually? -->
When starting Rails, you should see the build task being executed automatically with the watch task.

## Pre-merge checklist <!-- Things that should be done before merging. Feel free to add more boxes, especially if this is a WIP. -->

- [x] Build succeeds locally and in CI
- [x] Proper documentation (N/A)
- [x] Tests (N/A)
- [x] Git history cleaned up <!-- Mistake commits and unnecessary merge commits rebased away, proper commit message conventions followed: http://chris.beams.io/posts/git-commit/ -->
