### PR TITLE
Quick frontend build fixes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,7 @@ gulp.task('clean', () => {
 
 gulp.task('lint:js', () => {
   gulp.src(['app/gulp/js/**/*.js', '!node_modules/**', '!vendor/**'])
+    .pipe($.plumber())
     .pipe($.eslint())
     .pipe($.eslint.format())
     .pipe($.eslint.failAfterError());
@@ -21,6 +22,7 @@ gulp.task('lint:js', () => {
 
 gulp.task('build:js', ['lint:js'], () => {
   return gulp.src('app/gulp/js/**/*.js')
+    .pipe($.plumber())
     .pipe($.sourcemaps.init())
     .pipe($.babel())
     .pipe($.uglify())
@@ -30,6 +32,7 @@ gulp.task('build:js', ['lint:js'], () => {
 
 gulp.task('build:sass', () => {
   return gulp.src(['app/gulp/sass/**/*.sass', 'app/gulp/sass/**/*.scss'])
+    .pipe($.plumber())
     .pipe($.sourcemaps.init())
     .pipe($.sass().on('error', $.sass.logError))
     .pipe($.autoprefixer())

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   },
   "eslintConfig": {
     "extends": "airbnb-base",
+    "env": {
+      "browser": true
+    },
     "rules": {
       "no-param-reassign": [
         "error",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,13 @@
   "browserslist": [
     "> 1%"
   ],
+  "babel": {
+    "presets": [
+      [
+        "env"
+      ]
+    ]
+  },
   "eslintConfig": {
     "extends": "airbnb-base",
     "rules": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "gulp-concat": "^2.6.0",
     "gulp-eslint": "^3.0.1",
     "gulp-load-plugins": "^1.4.0",
+    "gulp-plumber": "^1.1.0",
     "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "^2.4.0",
     "gulp-uglify": "^2.0.1"


### PR DESCRIPTION
## Changes <!-- What does this pull request do/change? -->
This fixes several bugs in the frontend build that I found just now from poking around.
- [x] Fix eslint failing because it didn't think browser global variables like `alert` were defined
- [x] Fix there not being a babel config, and babel just sitting there doing nothing as a result
  - Interestingly, this could cause the uglify step to fail, as UglifyJS seems to lack support for some ES6 features
- [x] Make error messages in the build much nicer
  - This also makes the watch task continue running, even if compilation fails once

## Context <!-- Is there some background that reviewers need? -->
#43 added the initial frontend build.

## Testing <!-- What's the best way to try out the changes manually? -->
You can add these two lines to `app/gulp/js/app.js` and check that the output (at `vendor/assets/javascripts/gulp/app.js`) has gone through eslint and babel successfully.

Input:
```js
const helloFn = name => `Hello ${name}!`;
alert(helloFn('Alice'));
```

Output:
```js
"use strict";var helloFn=function(l){return"Hello "+l+"!"};alert(helloFn("Alice"));
//# sourceMappingURL=app.js.map
```

## Pre-merge checklist <!-- Things that should be done before merging. Feel free to add more boxes, especially if this is a WIP. -->

- [x] Build succeeds locally and in CI
- [x] Proper documentation (N/A)
- [x] Tests (N/A)
- [x] Git history cleaned up <!-- Mistake commits and unnecessary merge commits rebased away, proper commit message conventions followed: http://chris.beams.io/posts/git-commit/ -->
