### PR TITLE
Associate incorrect emails in commits with authors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,9 @@
+# A lot of commits were made without the authors setting their emails properly
+# To fix `git shortlog`, etc. without editing the history, we use this file
+
+Bikranta Dhamala <dhamalabikranta@gmail.com> <bik@Biks-MacBook-Pro.local>
+Bikranta Dhamala <dhamalabikranta@gmail.com> <bik@lawn-143-215-113-92.lawn.gatech.edu>
+Forester Vosburgh <fvosburgh3@gmail.com> <forester@Foresters-Air.1045>
+Forester Vosburgh <fvosburgh3@gmail.com> <forester@lawn-128-61-2-110.lawn.gatech.edu>
+Matthew Keezer <rmkeezer@yahoo.com>
+Matthew Keezer <rmkeezer@yahoo.com> <Matthew Keezer>


### PR DESCRIPTION
<!--
It's ok if the pull isn't ready to be merged yet; just prepend "[WIP]" to the title. This is a good idea if you want some preliminary feedback.

You can always insert screenshots if they will be helpful.

Don't forget to do the following:
- If this pull doesn't consist solely of superficial changes, make sure that all the questions below are answered (even with N/A) and that all the todos are checked.
- Assign the person/people with the most context to review this pull.
-->

## Changes <!-- What does this pull request do/change? If this is a WIP, add some checkboxes! -->

Add a `.mailmap` to associate incorrect emails with the real authors.

## Context <!-- Is there some background that reviewers need? Link any relevant issues (user stories, bug reports, questions, etc.) or pull requests here. -->

People have been committing without setting their emails properly, thus some repo statistics are messed up.

## Testing <!-- What's the best way to try out the changes manually? -->

Run `git shortlog -sne --no-merges`.

## Pre-merge checklist <!-- Things that should be done before merging. Check and say N/A if an item is not applicable. -->

Changes don't affect the app.

- [x] Build succeeds locally and in CI
- [x] Proper documentation
- [x] Tests
- [x] Git history clean <!-- Mistake commits and unnecessary merge commits rebased away, proper commit message conventions followed: http://chris.beams.io/posts/git-commit/ https://seesparkbox.com/foundry/atomic_commits_with_git -->
