### PR TITLE
Navbar background fills pages that have scrollbars

### DIFF
--- a/app/gulp/sass/_layout.scss
+++ b/app/gulp/sass/_layout.scss
@@ -16,10 +16,15 @@ html, body {
 }
 
 #top-bar {
+  position: absolute;
+
   background: $ui-gray-light;
   border-bottom: $tiniest-absolute solid $ui-gray-dark;
-  width: 100%;
+
   height: $top-bar-height;
+  top: 0;
+  width: 100%;
+
   z-index: 100; // Bar ends up on top -- always
 
   // Vertical centering hack
@@ -45,18 +50,33 @@ html, body {
 }
 
 nav {
-  position: absolute;
+  position: fixed;
 
   background: $ui-gray-light;
   border-right: $tiniest-absolute solid $ui-gray-dark;
 
   width: $sidebar-width;
-  top: $top-bar-height;
+
+  top: 0;
   bottom: 0;
   left: 0;
 
-  padding: $small;
+  padding: $top-bar-height + $small $small $small $small;
   z-index: 90;
+
+  a { // Each link expands to fill the li, so the whole area is clickable
+    display: block;
+    padding: $smaller;
+    text-decoration: none;
+
+    &:hover {
+      background: $ui-gray-darker;
+    }
+  }
+
+  hr {
+    margin: 0;
+  }
 
   ul {
     list-style-type: none;
@@ -66,20 +86,10 @@ nav {
       margin: 0;
     }
   }
-
-  a { // Each link expands to fill the li, so the whole area is clickable
-    display: block;
-    text-decoration: none;
-    padding: $smaller;
-
-    &:hover {
-      background: $ui-gray-darker;
-    }
-  }
 }
 
 #content {
-  margin-top: $content-margin;
+  margin-top: $top-bar-height + $content-margin;
   margin-bottom: $content-margin;
   margin-left: $sidebar-width + $content-margin * 2;
   margin-right: $content-margin;

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -20,13 +20,14 @@
           Logged in as
           = link_to(@current_user) do
             = @current_user.username
-            - if @current_user.role == 'instructor'
+            - if is_instructor?
               (instructor)
           \-
           = link_to(logout_path, method: "delete") do
             = fa_icon "sign-out"
             logout
       %nav#menu
+        %hr
         %ul
           %li
             = link_to('/home') do
@@ -49,6 +50,7 @@
             %a{:href => '#'}
               = fa_icon "cog fw"
               Settings
+        %hr
     #content.container
       - if check_privilege(controller_name, action_name)
         = yield


### PR DESCRIPTION
## Changes <!-- What does this pull request do/change? If this is a WIP, add some checkboxes! -->

Navbar is now fixed position and stays in the same place when scrolling. Added some horizontal rules so the navbar doesn't look too weird without the top bar visible.

![sidebar1](https://cloud.githubusercontent.com/assets/5883232/24015699/9553b50a-0a5f-11e7-98f5-ea7a866e26cc.png)

![sidebar2](https://cloud.githubusercontent.com/assets/5883232/24015705/98b3021e-0a5f-11e7-81e2-4e9a063f43da.png)

Do you think this feels weird at all, or is it fine?

## Context <!-- Is there some background that reviewers need? Link any relevant issues (user stories, bug reports, questions, etc.) or pull requests here. -->

Fixes #100.

## Testing <!-- What's the best way to try out the changes manually? -->

Checkout, go to a page with a scrollbar, and scroll for a bit.

## Pre-merge checklist <!-- Things that should be done before merging. Check and say N/A if an item is not applicable. -->

- [x] Build succeeds locally and in CI
- [x] Proper documentation
- [x] Tests
- [x] Git history clean <!-- Mistake commits and unnecessary merge commits rebased away, proper commit message conventions followed: http://chris.beams.io/posts/git-commit/ https://seesparkbox.com/foundry/atomic_commits_with_git -->
