### PR TITLE
Remove bundler hack

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,4 @@
 dependencies:
-  pre:
-    # Replace default bundler version, which is a bit older
-    - yes y | gem uninstall bundler
-    - gem install bundler --pre
   post:
     - npm run build
 


### PR DESCRIPTION
## Changes <!-- What does this pull request do/change? If this is a WIP, add some checkboxes! -->

I noticed in the logs that CircleCI has begun shipping the latest version of bundler in their containers, so reinstalling bundler is no longer necessary.

## Context <!-- Is there some background that reviewers need? Link any relevant issues (user stories, bug reports, questions, etc.) or pull requests here. -->

N/A.

## Testing <!-- What's the best way to try out the changes manually? -->

N/A.

## Pre-merge checklist <!-- Things that should be done before merging. Check and say N/A if an item is not applicable. -->

- [x] Build succeeds locally and in CI
- [x] Proper documentation (N/A)
- [x] Tests (N/A)
- [x] Git history clean <!-- Mistake commits and unnecessary merge commits rebased away, proper commit message conventions followed: http://chris.beams.io/posts/git-commit/ https://seesparkbox.com/foundry/atomic_commits_with_git -->
