### PR TITLE
Fix students can view published question only

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -41,11 +41,11 @@ class QuestionsController < ApplicationController
         @question.answers.build(:content => value[:content][0], :correct => value[:correct])
       end
     end
-    @question.published_at = Time.zone.now if publishing?
+    @question.published_at = Time.current if publishing?
 
     respond_to do |format|
       if @question.save
-        @question.published_at = Time.zone.now if publishing?
+        @question.published_at = Time.current if publishing?
         format.html { redirect_to @question, notice: 'Question was successfully created.' }
         format.json { render :show, status: :created, location: @question }
       else
@@ -58,7 +58,7 @@ class QuestionsController < ApplicationController
   # PATCH/PUT /questions/1
   # PATCH/PUT /questions/1.json
   def update
-    @question.published_at = Time.zone.now if publishing?
+    @question.published_at = Time.current if publishing?
     respond_to do |format|
       if @question.update(question_params)
         @question.correct_answer.update(question_params[:correct_answer_attributes])

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -11,10 +11,14 @@ class Question < ApplicationRecord
 
   accepts_nested_attributes_for :answers, :correct_answer
   validates :correct_answer, presence: true
- 
-  	def published
-  		published_at
-  	end
+
+  def published
+  	published_at
+  end
+
+  def published?
+    published_at?
+  end
 
   def all_topics=(names)
     self.topics = names.split(",").map do |name|

--- a/app/views/questions/index.html.haml
+++ b/app/views/questions/index.html.haml
@@ -12,18 +12,20 @@
 
   %tbody
     - @questions.each do |question|
-      %tr
-        %td= get_user(question.user_id).username
-        %td= question.all_lectures
-        %td= question.all_topics
-        %td= question.content
-        %td= question.published
-        %td
-          = link_to 'Show', question
-          \-
-          = link_to 'Edit', edit_question_path(question)
-          \-
-          = link_to 'Destroy', question, :method => :delete, :data => { :confirm => 'Are you sure?' }
+      - if is_instructor? or question.published?
+        %tr
+          %td= get_user(question.user_id).username
+          %td= question.all_lectures
+          %td= question.all_topics
+          %td= question.content
+          %td= question.published
+          %td
+            = link_to 'Show', question
+            - if is_instructor?
+              \-
+              = link_to 'Edit', edit_question_path(question)
+              \-
+              = link_to 'Destroy', question, :method => :delete, :data => { :confirm => 'Are you sure?' }
 %br
 
 - if is_instructor?

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 20170313020218) do
-
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
<!--
It's ok if the pull isn't ready to be merged yet; just prepend "[WIP]" to the title. This is a good idea if you want some preliminary feedback.

You can always insert screenshots if they will be helpful.

Don't forget to do the following:
- If this pull doesn't consist solely of superficial changes, make sure that all the questions below are answered (even with N/A) and that all the todos are checked.
- Assign the person/people with the most context to review this pull.
-->

## Changes <!-- What does this pull request do/change? If this is a WIP, add some checkboxes! -->
- Students can view only published questions.
- Student can't edit or delete the question.

## Context <!-- Is there some background that reviewers need? Link any relevant issues (user stories, bug reports, questions, etc.) or pull requests here. -->

## Testing <!-- What's the best way to try out the changes manually? -->
- Instructor should create two questions and publish one of it and students can only see the published question without options to delete or edit the question.  

## Pre-merge checklist <!-- Things that should be done before merging. Check and say N/A if an item is not applicable. -->

- [ ] Build succeeds locally and in CI
- [ ] Proper documentation
- [ ] Tests
- [ ] Git history clean <!-- Mistake commits and unnecessary merge commits rebased away, proper commit message conventions followed: http://chris.beams.io/posts/git-commit/ https://seesparkbox.com/foundry/atomic_commits_with_git -->
