### PR TITLE
Centralize flashes into layout

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -85,7 +85,7 @@ class QuestionsController < ApplicationController
     respond_to do |format|
       if @question.save
         @question.published_at = Time.current if publishing?
-        format.html { redirect_to @question, notice: 'Question was successfully created.' }
+        format.html { redirect_to @question, :flash => { :success => 'Question successfully created' } }
         format.json { render :show, status: :created, location: @question }
       else
         format.html { render :new }
@@ -102,7 +102,7 @@ class QuestionsController < ApplicationController
       if @question.update(question_params)
         @question.correct_answer.update(question_params[:correct_answer_attributes])
         update_answers
-        format.html { redirect_to @question, notice: 'Question was successfully updated.' }
+        format.html { redirect_to @question, :flash => { :success => 'Question successfully updated' } }
         format.json { render :show, status: :ok, location: @question }
       else
         format.html { render :edit }
@@ -116,7 +116,7 @@ class QuestionsController < ApplicationController
   def destroy
     @question.destroy
     respond_to do |format|
-      format.html { redirect_to questions_url, notice: 'Question was successfully destroyed.' }
+      format.html { redirect_to questions_url, :flash => { :success => 'Question successfully destroyed' } }
       format.json { head :no_content }
     end
   end
@@ -125,7 +125,7 @@ class QuestionsController < ApplicationController
   def submit_question
     current_user.answers << Answer.find_by_id(params[:answer])
     respond_to do |format|
-        format.html { redirect_to questions_url, notice: 'Questions successfully answered.' }
+        format.html { redirect_to questions_url, :flash => { :success => 'Question successfully answered' } }
     end
   end
 
@@ -169,9 +169,9 @@ class QuestionsController < ApplicationController
   def import_csv
     begin
       Question.import(params[:file], current_user)
-      redirect_to questions_path, notice: 'Upload successful'
+      redirect_to questions_path, :flash => { :success => 'Upload successful' }
     rescue
-      redirect_to questions_path, notice: 'Upload failed (bad CSV)'
+      redirect_to questions_path, error: 'Upload failed (bad CSV)'
     end
   end
 

--- a/app/gulp/sass/_error.scss
+++ b/app/gulp/sass/_error.scss
@@ -4,6 +4,9 @@
 
 $error-width: 45rem;
 
+$flash-error-color: #db1e1e;
+$flash-success-color: #1edb1e;
+
 pre {
   background-color: #eee;
   padding: $small;
@@ -14,8 +17,19 @@ div.actions {
   margin-bottom: 1rem;
 }
 
-#notice {
-  color: green;
+#flash-box { // Flash/notice styles
+  background-color: $ui-gray-light;
+  border: 1px solid $ui-gray-dark;
+  padding-top: $smaller;
+  padding-bottom: $smaller;
+  text-align: center;
+
+  .flash-error {
+    color: $flash-error-color;
+  }
+  .flash-success {
+    color: $flash-success-color;
+  }
 }
 
 .field_with_errors {

--- a/app/gulp/sass/_layout.scss
+++ b/app/gulp/sass/_layout.scss
@@ -106,7 +106,7 @@ nav {
   margin-top: $top-bar-height + $content-margin;
   margin-bottom: $content-margin;
   margin-left: $sidebar-width + $content-margin * 2;
-  margin-right: $content-margin;
+  margin-right: $content-margin * 2;
 
   height: 100%;
   width: auto;

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -48,7 +48,13 @@
                 %span.mobile-hide Roster
         %hr
     #content.container
-      #modal-window.modal.fade{"aria-hidden" => "true", "aria-labelledby" => "myModalLabel", :role => "dialog"}
+      - if logged_in?
+        #modal-window.modal.fade{"aria-hidden" => "true", "aria-labelledby" => "myModalLabel", :role => "dialog"}
+      - if !flash.empty?
+        #flash-box
+          - flash.each do |key, message|
+            %div{:class => "flash-#{key}"}= message
+
       - if check_privilege(controller_name, action_name)
         = yield
       - else

--- a/app/views/login/login.html.haml
+++ b/app/views/login/login.html.haml
@@ -1,7 +1,5 @@
-- flash.each do |_, value|
-  .error= value
-
 - provide(:title, "Log in")
+
 %h1 Log in
 = form_for(:login, url: login_path) do |f|
   = f.label :username


### PR DESCRIPTION
## Changes <!-- What does this pull request do/change? If this is a WIP, add some checkboxes! -->

Ensure that flash messages always show up by adding flash display to the layout. Also make flashes a lot prettier.

![hello](https://cloud.githubusercontent.com/assets/5883232/25354024/5090c534-28ff-11e7-9bad-994e98d2753c.png)

## Context <!-- Is there some background that reviewers need? Link any relevant issues (user stories, bug reports, questions, etc.) or pull requests here. -->

Fixes #137.

## Testing <!-- What's the best way to try out the changes manually? -->

See Heroku.

## Pre-merge checklist <!-- Things that should be done before merging. Check and say N/A if an item is not applicable. -->

- [x] Build succeeds locally and in CI
- [x] Proper documentation
- [x] Tests (N/A)
- [x] Git history clean <!-- Mistake commits and unnecessary merge commits rebased away, proper commit message conventions followed: http://chris.beams.io/posts/git-commit/ https://seesparkbox.com/foundry/atomic_commits_with_git -->
